### PR TITLE
Clarification on html forms

### DIFF
--- a/_demo/index.html
+++ b/_demo/index.html
@@ -218,7 +218,7 @@
             <header>
                 <h1>Custom class/ID</h1>
                 <p><span class="option">""</span> by default</p>
-                <p>Maybe you have multiple selects on the same page and one should look different, or whatever need you can find for a custom class/ID. In this example we're using a custom class give the SoD a different look.</p>
+                <p>Maybe you have multiple selects on the same page and one should look different, or whatever need you can find for a custom class/ID. In this example we're using a custom class give the SoD a different look. This custom-id also works for HTML forms, for retrieving values via $_POST.</p>
             </header>
 
             <pre>


### PR DESCRIPTION
Points out that custom-id works with HTML forms for $_POST values. Would've saved me a lot of trouble if I had seen this earlier.

Me (and probably some other people as well) did not realise that SoD doesn't do anything with the "id" applied to the element's <select>, meaning **data-custom-id** is how you want to go about setting the ID for use in an HTML form.
