### PR TITLE
Fix Windows 8 issue relating to focus and scope.

### DIFF
--- a/_src/selectordie.js
+++ b/_src/selectordie.js
@@ -211,7 +211,11 @@
             }, // populateSoD
 
 
-            focusSod: function () {
+            focusSod: function (e) {
+                if( $(e.target).hasClass('sod_label') || $(e.target).hasClass('sod_option')){
+                    return;
+                }
+                
                 var $sod        = $(this),
                     $sodInFocus = $(".sod_select.focus");
 


### PR DESCRIPTION
The issue being that the `.sod_list_wrapper` does not properly show and the selection is not processed. I'm sure @cah4a can explain this better.

This commit from @cah4a fixes issues under Windows 8 with Internet Explorer and Chrome (and possibly Firefox).

This resolves (based on the conversations) the following issues : #6, #7, #14
